### PR TITLE
Update API routes to include 'require-registered' middleware for noti…

### DIFF
--- a/Modules/Notifications/Routes/api.php
+++ b/Modules/Notifications/Routes/api.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Route;
 use Modules\Notifications\App\Http\Controllers\NotificationsController;
 
 Route::prefix('notifications')->as('notifications.')->controller(NotificationsController::class)->group(function () {
-    Route::group(['middleware' => ['auth:api']], function () {
+    Route::group(['middleware' => ['auth:api', 'require-registered']], function () {
         Route::get('list', 'list');
         Route::post('read/{id}', 'read');
         Route::post('read-all', 'readAll');

--- a/Modules/Users/Routes/api.php
+++ b/Modules/Users/Routes/api.php
@@ -4,7 +4,7 @@ use Illuminate\Support\Facades\Route;
 use Modules\Users\App\Http\Controllers\UsersController;
 
 Route::prefix('users')->as('users.')->controller(UsersController::class)->group(function () {
-    Route::group(['middleware' => ['auth:api']], function () {
+    Route::group(['middleware' => ['auth:api', 'require-registered']], function () {
         //
     });
 });


### PR DESCRIPTION
…fications and users

- Enhanced the route groups for both notifications and users by adding the 'require-registered' middleware alongside the existing 'auth:api' middleware, ensuring that only registered users can access these routes.