### PR TITLE
Update PullCommand signature and description for clarity

### DIFF
--- a/app/Console/Commands/PullCommand.php
+++ b/app/Console/Commands/PullCommand.php
@@ -11,14 +11,14 @@ class PullCommand extends Command
      *
      * @var string
      */
-    protected $signature = 'pull';
+    protected $signature = 'git:pull';
 
     /**
      * The console command description.
      *
      * @var string
      */
-    protected $description = 'Pull the latest changes from the remote repository';
+    protected $description = 'Pull the latest changes from the remote repository using git';
 
     /**
      * Execute the console command.

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -36,7 +36,7 @@ return Application::configure(basePath: dirname(__DIR__))
         ]);
     })
     ->withSchedule(function (Schedule $schedule) {
-        $schedule->command('pull')->everyTwoMinutes();
+        $schedule->command('git:pull')->everyTwoMinutes();
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         $exceptions->render(function (NotFoundHttpException $e, Request $request) {


### PR DESCRIPTION
- Changed the command signature from 'pull' to 'git:pull' to better reflect its functionality.
- Enhanced the command description to specify that it pulls the latest changes using git, improving user understanding.