### PR TITLE
Add confirm password validation to registration request

### DIFF
--- a/Modules/Auth/App/Http/Requests/RegisterRequest.php
+++ b/Modules/Auth/App/Http/Requests/RegisterRequest.php
@@ -24,6 +24,7 @@ class RegisterRequest extends FormRequest
             'mobile' => ['required', 'regex:' . getMobileRegexBasedOnCountryCode($this->mobile_country_code)],
             'mobile_country_code' => 'required|string|max:255',
             'password' => 'required|string|max:255',
+            'confirm_password' => 'required|string|max:255|same:password',
             'device_token' => ['required'],
             'device_type' => ['required', Rule::in(DeviceTokenType::ANDROID, DeviceTokenType::IOS)],
             'device_brand' => 'nullable|string|max:255',
@@ -67,6 +68,8 @@ class RegisterRequest extends FormRequest
             'device_brand.required' => __('auth::messages.device_brand_required'),
             'device_brand.string' => __('auth::messages.device_brand_string'),
             'device_brand.max' => __('auth::messages.device_brand_max'),
+            'confirm_password.required' => __('auth::messages.confirm_password_required'),
+            'confirm_password.same' => __('auth::messages.confirm_password_same'),
         ];
     }
 
@@ -85,6 +88,7 @@ class RegisterRequest extends FormRequest
             'mobile_country_code' => __('auth::messages.attributes.mobile_country_code'),
             'password' => __('auth::messages.attributes.password'),
             'device_brand' => __('auth::messages.attributes.device_brand'),
+            'confirm_password' => __('auth::messages.attributes.confirm_password'),
         ];
     }
 

--- a/Modules/Auth/Lang/ar/messages.php
+++ b/Modules/Auth/Lang/ar/messages.php
@@ -51,6 +51,8 @@ return [
     'social_token_required' => 'رمز التسجيل الاجتماعي مطلوب',
     'invalid_social_token' => 'رمز التسجيل الاجتماعي غير صالح',
     'social_login_successfully' => 'تم تسجيل الدخول بنجاح باستخدام التسجيل الاجتماعي',
+    'confirm_password_required' => 'تأكيد كلمة المرور مطلوب',
+    'confirm_password_same' => 'تأكيد كلمة المرور يجب أن يتطابق مع كلمة المرور الجديدة',
     'attributes' => [
         'mobile' => 'الهاتف',
         'mobile_country_code' => 'رمز الدولة',
@@ -66,5 +68,6 @@ return [
         'social_type' => 'نوع التسجيل الاجتماعي',
         'social_profile_id' => 'معرف المستخدم في التسجيل الاجتماعي',
         'social_token' => 'رمز التسجيل الاجتماعي',
+        'confirm_password' => 'تأكيد كلمة المرور',
     ],
 ];

--- a/Modules/Auth/Lang/en/messages.php
+++ b/Modules/Auth/Lang/en/messages.php
@@ -51,6 +51,8 @@ return [
     'social_token_required' => 'Social token is required',
     'invalid_social_token' => 'Invalid social token',
     'social_login_successfully' => 'Social login successfully',
+    'confirm_password_required' => 'Confirm password is required',
+    'confirm_password_same' => 'Confirm password must be same as new password',
     'attributes' => [
         'mobile' => 'Mobile',
         'mobile_country_code' => 'Mobile country code',
@@ -66,5 +68,6 @@ return [
         'social_type' => 'Social type',
         'social_profile_id' => 'Social profile id',
         'social_token' => 'Social token',
+        'confirm_password' => 'Confirm password',
     ],
 ];


### PR DESCRIPTION
- Introduced 'confirm_password' field in RegisterRequest with validation rules to ensure it matches the 'password' field.
- Added corresponding error messages for 'confirm_password' in both Arabic and English language files.
- Updated attributes in language files to include 'confirm_password' for better user feedback during registration.